### PR TITLE
Fix COAP compiling with Mongoose eac6a9

### DIFF
--- a/mongoose/mongoose.c
+++ b/mongoose/mongoose.c
@@ -11517,14 +11517,15 @@ uint32_t mg_coap_send_ack(struct mg_connection *nc, uint16_t msg_id) {
   return mg_coap_send_message(nc, &cm);
 }
 
-static void coap_handler(struct mg_connection *nc, int ev, void *ev_data) {
+static void coap_handler(struct mg_connection *nc, int ev, void *ev_data, void *user_data) {
+  (void) user_data;
   struct mbuf *io = &nc->recv_mbuf;
   struct mg_coap_message cm;
   uint32_t parse_res;
 
   memset(&cm, 0, sizeof(cm));
 
-  nc->handler(nc, ev, ev_data);
+  nc->handler(nc, ev, ev_data, NULL);
 
   switch (ev) {
     case MG_EV_RECV:
@@ -11537,7 +11538,7 @@ static void coap_handler(struct mg_connection *nc, int ev, void *ev_data) {
            */
           cm.flags |= MG_COAP_FORMAT_ERROR; /* LCOV_EXCL_LINE */
         }                                   /* LCOV_EXCL_LINE */
-        nc->handler(nc, MG_COAP_EVENT_BASE + cm.msg_type, &cm);
+        nc->handler(nc, MG_COAP_EVENT_BASE + cm.msg_type, &cm, NULL);
       }
 
       mg_coap_free_options(&cm);


### PR DESCRIPTION
COAP functionality is broken with new approach for separating user_data argument. 

Also if MG_ENABLE_CALLBACK_USERDATA is disable, there is problem with using timers - user_data is extra param and could not be removed, so compilation again fails.
```
static void mgos_timer_ev(struct mg_connection *nc, int ev, void *ev_data,
                          void *user_data)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose-os/215)
<!-- Reviewable:end -->
