### PR TITLE
Support dockerised build of mos, on both PC and ARM.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+#!./tools/docker-build-wrapper -t mos-armhf
+#
+# Construct a docker image that contains a built installation
+# of Mongoose OS 'mos' tool,
+#
+# The constructed Docker image serves Mongoose OS IDE on HTTP port 1992.
+#
+# Run this docker image with:
+#   docker run -v /dev/ttyUSB0:/dev/ttyUSB0 --privileged -p 1992:1992 mos-armhf
+#
+# Connect to your running mos using your web browser to request:
+#   http://address-of-your-docker-host:1992/
+#
+
+#
+# As there is no offical armhf golang image, you must build one using
+# Dockerfile-golang-armhf.
+#
+FROM golang
+
+#
+# Install Go tools and libraries needed by Mongoose OS
+#
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends libftdi-dev python-git && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/*
+RUN go get github.com/kardianos/govendor
+ADD . /go/src/cesanta.com
+WORKDIR /go/src/cesanta.com/mos
+RUN govendor sync
+
+#
+# Build Mongoose OS
+#
+RUN make install
+ENV MOS_LISTEN_ADDR 0.0.0.0:1992
+EXPOSE 1992
+CMD ["/go/bin/mos"]

--- a/Dockerfile-armhf
+++ b/Dockerfile-armhf
@@ -1,0 +1,39 @@
+#!./tools/docker-build-wrapper -t mos-armhf
+#
+# Construct a docker image that contains a built installation
+# of Mongoose OS 'mos' tool,
+#
+# The constructed Docker image serves Mongoose OS IDE on HTTP port 1992.
+#
+# Run this docker image with:
+#   docker run -v /dev/ttyUSB0:/dev/ttyUSB0 --privileged -p 1992:1992 mos-armhf
+#
+# Connect to your running mos using your web browser to request:
+#   http://address-of-your-docker-host:1992/
+#
+
+#
+# As there is no offical armhf golang image, you must build one using
+# Dockerfile-golang-armhf.
+#
+FROM golang-armhf
+
+#
+# Install Go tools and libraries needed by Mongoose OS
+#
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends libftdi-dev python-git && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/*
+RUN go get github.com/kardianos/govendor
+ADD . /go/src/cesanta.com
+WORKDIR /go/src/cesanta.com/mos
+RUN govendor sync
+
+#
+# Build Mongoose OS
+#
+RUN make install
+ENV MOS_LISTEN_ADDR 0.0.0.0:1992
+EXPOSE 1992
+CMD ["/go/bin/mos"]

--- a/Dockerfile-golang-armhf
+++ b/Dockerfile-golang-armhf
@@ -1,0 +1,31 @@
+#!./tools/docker-build-wrapper -t golang-armhf
+#
+# Construct a workalike of the official Docker 'golang' container
+# that is suitable for ARM Linux (Raspberry Pi, Orange Pi, Nano Pi etc.)
+#
+#
+
+FROM armhf/ubuntu
+
+#
+# Install compilers and tools neeeded to build Go libraries
+#
+#	apt-get install -y --no-install-recommends apt-utils && \
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends g++ gcc libc6-dev make pkg-config curl ca-certificates && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/*
+
+#
+# Install the official Go environment from golang.org
+#
+RUN curl -fsSL https://golang.org/dl/go1.8.linux-armv6l.tar.gz | tar -C /usr/local -zxf -
+
+#
+# Set up the work environment in /go
+#
+ENV GOROOT /usr/local/go
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+WORKDIR $GOPATH

--- a/README.md
+++ b/README.md
@@ -39,4 +39,60 @@ To submit contributions, sign
 [Cesanta CLA](https://docs.cesanta.com/contributors_la.shtml)
 and send GitHub pull request. You retain the copyright on your contributions.
 
+## Building the mos tool for developers
+
+### Dockerised builds
+
+First, install Docker using the instructions from [download.docker.com](https://download.docker.com/).
+
+**For PC or Mac**, simply do
+
+```
+docker build -t mos .
+docker run -p 1992:1992 -v /dev/ttyUSB0:/dev/ttyUSB0 --privileged mos
+```
+
+If you are on a Mac, change the first ttyUSB0 to whatever your Mac calls your attached device (leave the second one alone).
+
+**For Raspberry Pi and other ARM SBCs**, (Beagle Bone, Orange Pi, Nano Pi etc), do:
+
+```
+docker build -t golang-armhf -f Dockerfile-golang-armhf .
+docker build -t mos -f Dockerfile-armhf .
+docker run -p 1992:1992 -v /dev/ttyUSB0:/dev/ttyUSB0 --privileged mos
+```
+
+A Dockerised build allows you to run the Mongoose OS UI on a separate
+system (such as a battery powered Raspberry Pi) giving you a shareable
+and portable device programming station.
+
+### Local builds
+
+This presumes you are using Debian or Ubuntu.
+
+**Install Go**
+
+Install go using the instructions from [golang.org](http://golang.org).  (You could
+also type `sudo apt install golang`, but you will get an older version of Go)
+
+**Install dependencies**
+
+```
+apt install libftdi-dev python-git
+go get -v github.com/kardianos/govendor
+```
+
+**Check out and build Mongoose OS**
+
+```
+git clone https://github.com/cesanta/mongoose-os/
+cd mongoose-os
+ln -s $PWD $GOPATH/src/cesanta.com
+cd mos
+go get -d -v
+govendor fetch github.com/jteeuwen/go-bindata/go-bindata
+govendor fetch github.com/elazarl/go-bindata-assetfs/go-bindata-assetfs
+make install
+```
+
 [![Analytics](https://ga-beacon.appspot.com/UA-42732794-6/project-page)](https://github.com/cesanta/mongoose-os)

--- a/mos/ui.go
+++ b/mos/ui.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -39,6 +40,7 @@ const (
 )
 
 var (
+	httpAddr     = "127.0.0.1"
 	httpPort     = 1992
 	udpAddr      = ":1993"
 	wsClients    = make(map[*websocket.Conn]int)
@@ -561,18 +563,27 @@ func startUI(ctx context.Context, devConn *dev.DevConn) error {
 		http.Handle("/", addExpiresHeader(expireTime, http.FileServer(&assetfs.AssetFS{Asset: Asset,
 			AssetDir: AssetDir, AssetInfo: assetInfo, Prefix: "web_root"})))
 	}
-	addr := fmt.Sprintf("127.0.0.1:%d", httpPort)
-	url := fmt.Sprintf("http://%s", addr)
+
+	addr := os.Getenv("MOS_LISTEN_ADDR")
+	if len(addr) == 0 {
+		addr = fmt.Sprintf("%s:%d", httpAddr, httpPort)
+	}
 
 	fmt.Printf("To get a list of available commands, start with --help\n")
-	fmt.Printf("Starting Web UI. If the browser does not start, navigate to %s\n", url)
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		os.Stdout = origStdout
 		os.Stderr = origStderr
 		return errors.Trace(err)
 	}
+	if strings.Index(addr, "0.0.0.0:") == 0 {
+		// We're listening on all interfaces (probably Dockerised)
+		fmt.Printf("UI is listenting on [%s].", addr)
+		startBrowser = false;
+	}
 	if startBrowser {
+		url := fmt.Sprintf("http://%s", addr)
+		fmt.Printf("Starting Web UI. If the browser does not start, navigate to %s\n", url)
 		open.Start(url)
 	}
 	http.Serve(listener, nil)

--- a/tools/docker-build-wrapper
+++ b/tools/docker-build-wrapper
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# This script lets you build a dockerfile by running as ./Dockerfile
+# if you put a "shebang" in the first line of the Dockerfile, eg:
+#
+# 	#!./tools/docker-build-wrapper -t mos
+#
+# (BTW, this works on Linux, but not on Mac)
+#
+DOCKERFILE=${@: -1}
+ARGS="${@:1:$#-1}"
+exec docker build $ARGS -f $DOCKERFILE .


### PR DESCRIPTION
Add documentation on how to build mos, both locally and in docker.

Add Dockerfiles for dockerised build, and a wrapper script to simplify docker builds.

This commit allows one to build a docker container that runs the mos service,
supporting easily installing MOS on a machine other than the developer's workstation.

In particular, this allows one to use a Raspberry Pi as a mos host, removing
any risk of damaging one's PC in case of faulty wiring on the target board.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose-os/222)
<!-- Reviewable:end -->
