### PR TITLE
Allocate error message string when writing to file failed

### DIFF
--- a/fw/src/mgos_sys_config.c
+++ b/fw/src/mgos_sys_config.c
@@ -119,7 +119,7 @@ bool save_cfg(const struct sys_config *cfg, char **msg) {
     LOG(LL_INFO, ("Saved to %s", CONF_USER_FILE));
     result = true;
   } else {
-    *msg = "failed to write file";
+    *msg = strdup("failed to write file");
   }
 clean:
   mgos_conf_free(sys_config_schema(), &defaults);


### PR DESCRIPTION
Documentation states that the message must be freed but this branch in the code doesn't allocate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose-os/223)
<!-- Reviewable:end -->
