### PR TITLE
eliminating undesired bitbanging transitions

### DIFF
--- a/fw/src/mgos_bitbang.c
+++ b/fw/src/mgos_bitbang.c
@@ -24,14 +24,14 @@ IRAM static void mgos_bitbang_write_bits2(int gpio,
     uint8_t b = *data++;
     for (int i = 0; i < 8; i++) {
       if (b & 0x80) {
-        mgos_gpio_write(gpio, 1);
+        mgos_gpio_write(gpio, t1h);
         delay_fn(t1h);
-        mgos_gpio_write(gpio, 0);
+        mgos_gpio_write(gpio, !t1l);
         delay_fn(t1l);
       } else {
-        mgos_gpio_write(gpio, 1);
+		    mgos_gpio_write(gpio, t0h);
         delay_fn(t0h);
-        mgos_gpio_write(gpio, 0);
+		    mgos_gpio_write(gpio, !t0l);
         delay_fn(t0l);
       }
       b <<= 1;


### PR DESCRIPTION
If we're looking at a '1' bit or a '0' bit:
if the bit will go high for a period of time, write it high, otherwise keep it low
if the bit will go low for a period of time, write it low, otherwise keep it high

Found that writing
uint8_t array[] = {0x00, 0x0F, 0xF0, 0xAA};
mgos_bitbang_write_bits(14, MGOS_DELAY_USEC, 0, 104, 104, 0, array, 4);
resulted in extra transitions: https://ibb.co/dqnr7k