### PR TITLE
mg_get_http_var() returns -4 when var is not in query

### DIFF
--- a/mongoose/mongoose.c
+++ b/mongoose/mongoose.c
@@ -7003,6 +7003,7 @@ int mg_get_http_var(const struct mg_str *buf, const char *name, char *dst,
    * -1 - src is wrong (NUUL)
    * -2 - dst is wrong (NULL)
    * -3 - failed to decode url or dst is to small
+   * -4 - name does not exist
    */
   if (dst == NULL || dst_len == 0) {
     len = -2;
@@ -7012,7 +7013,7 @@ int mg_get_http_var(const struct mg_str *buf, const char *name, char *dst,
   } else {
     name_len = strlen(name);
     e = buf->p + buf->len;
-    len = 0;
+    len = -4;
     dst[0] = '\0';
 
     for (p = buf->p; p + name_len < e; p++) {


### PR DESCRIPTION
This change allows the user to distinguish between `name` being present in the request with an empty value and missing altogether.