### PR TITLE
Allow ESP8285 to use GPIO 9 and 10

### DIFF
--- a/fw/platforms/esp8266/src/esp_gpio.c
+++ b/fw/platforms/esp8266/src/esp_gpio.c
@@ -58,7 +58,11 @@ void gpio16_input_conf(void) {
 }
 
 // Returns true if the chip we're running on is ESP8285, false otherwise
-static bool is_esp8285() {
+IRAM bool is_esp8285() {
+  uint32_t efuse0 = ntohl(READ_PERI_REG(0x3ff00050));
+  uint32_t efuse2 = ntohl(READ_PERI_REG(0x3ff00058));
+  if (efuse0&(1<<4) != 0 || efuse2&(1<<16) != 0)
+    return true;
   return false;
 }
 
@@ -72,14 +76,16 @@ IRAM bool mgos_gpio_set_mode(int pin, enum mgos_gpio_mode mode) {
     return true;
   }
 
-  if (is_esp8285() && (pin >= 6 && pin <= 8) || (pin == 11)) {
-    /*
-     * NOTE(pimvanpelt) - ESP8285 has SPI flash memory internally connected in
-     * DOUT mode, pins 9 and 10 may be used as GPIO / I2C / PWM pins
-     */
-    LOG(LL_ERROR, ("GPIO%d is used by SPI flash, don't use it", pin));
-    return false;
-  } else if (pin >= 6 && pin <= 11) {
+  if (pin >= 6 && pin <= 11) {
+    if (is_esp8285()) {
+      if (pin!=9 && pin!=10) {
+        LOG(LL_ERROR, ("ESP8285 GPIO%d is used by SPI flash, don't use it", pin));
+        return false;
+      }
+    } else {
+      LOG(LL_ERROR, ("ESP8266 GPIO%d is used by SPI flash, don't use it", pin));
+      return false;
+    }
     /*
      * Alright, so you're here to investigate what's up with this error. So,
      * GPIO6-11 are used for SPI flash and messing with them causes crashes.
@@ -92,8 +98,6 @@ IRAM bool mgos_gpio_set_mode(int pin, enum mgos_gpio_mode mode) {
      * So really, just stay away from GPIO6-11 if you can help it.
      * If you are sure you know what you're doing, copy the code below.
      */
-    LOG(LL_ERROR, ("GPIO%d is used by SPI flash, don't use it", pin));
-    return false;
   }
 
   const struct gpio_info *gi = get_gpio_info(pin);

--- a/fw/platforms/esp8266/src/esp_gpio.c
+++ b/fw/platforms/esp8266/src/esp_gpio.c
@@ -67,6 +67,12 @@ IRAM bool mgos_gpio_set_mode(int pin, enum mgos_gpio_mode mode) {
     return true;
   }
 
+#ifdef ESP8285
+  if ((pin >= 6 && pin <= 8) || (pin == 11)) {
+    LOG(LL_ERROR, ("GPIO%d is used by SPI flash, don't use it", pin));
+    return false;
+  }
+#else
   if (pin >= 6 && pin <= 11) {
     LOG(LL_ERROR, ("GPIO%d is used by SPI flash, don't use it", pin));
     /*
@@ -80,9 +86,13 @@ IRAM bool mgos_gpio_set_mode(int pin, enum mgos_gpio_mode mode) {
      * crash most ESP8266 modules, but in a different way.
      * So really, just stay away from GPIO6-11 if you can help it.
      * If you are sure you know what you're doing, copy the code below.
+     *
+     * NOTE(pimvanpelt) - ESP8285 has SPI flash memory internally connected in
+     * DOUT mode, pins 9 and 10 may be used as GPIO / I2C / PWM pins
      */
     return false;
   }
+#endif
 
   const struct gpio_info *gi = get_gpio_info(pin);
   if (gi == NULL) return false;


### PR DESCRIPTION
ESP8285 has SPI flash memory internally connected in DOUT mode,
so pins 9 and 10 may be used as GPIO / I2C / PWM pins.

Add a non-intrusive #define ESP8285 to allow using these pins.
To enable, add to `mos.yml`:
```
cdefs:
  ESP8285: 1
```

Note on intent -- itead.cc have a device called Sonoff, and one of their variants, the Sonoff 4CH is based on ESP8285 rather than the more popular ESP8266. This device exposes pushbuttons on GPIO0, 9, 10 and 14. This change allows users on the ESP8285 platform to benefit from those two pins.

Tested on a barebones Mongoose OS application with rpc-service-gpio library. Without the patch, reading pin9 and pin10 throws error `400: error setting pin mode`, with the patch, pin9 and pin10 can be read (and obviously, written to).