### PR TITLE
Allow usage of inverted UART lines for ESP32

### DIFF
--- a/fw/platforms/esp32/src/esp32_uart.c
+++ b/fw/platforms/esp32/src/esp32_uart.c
@@ -356,11 +356,11 @@ bool mgos_uart_hal_configure(struct mgos_uart_state *us,
 
   uint32_t conf0 = UART_TICK_REF_ALWAYS_ON;
 
-  if (cfg->dev->tx_inverted) {
+  if (cfg->dev.tx_inverted) {
     conf0 |= UART_TXD_INV;
   }
 
-  if (cfg->dev->rx_inverted) {
+  if (cfg->dev.rx_inverted) {
     conf0 |= UART_RXD_INV;
   }
 

--- a/fw/platforms/esp32/src/esp32_uart.c
+++ b/fw/platforms/esp32/src/esp32_uart.c
@@ -356,6 +356,14 @@ bool mgos_uart_hal_configure(struct mgos_uart_state *us,
 
   uint32_t conf0 = UART_TICK_REF_ALWAYS_ON;
 
+  if (cfg->dev->tx_inverted) {
+    conf0 |= UART_TXD_INV;
+  }
+
+  if (cfg->dev->rx_inverted) {
+    conf0 |= UART_RXD_INV;
+  }
+
   switch (cfg->num_data_bits) {
     case 5:
       break;

--- a/fw/platforms/esp32/src/esp32_uart.h
+++ b/fw/platforms/esp32/src/esp32_uart.h
@@ -50,6 +50,9 @@ struct mgos_uart_dev_config {
    * UART 2: Rx: 16, Tx: 17, CTS: 14, RTS: 15
    */
 
+  bool tx_inverted;
+  bool rx_inverted;
+
   int8_t rx_gpio;
   int8_t tx_gpio;
   int8_t cts_gpio;


### PR DESCRIPTION
Need the capability of the ESP32 to invert UART lines. This change should expose the feature to the mongoose-api.