### PR TITLE
Fixed: Behaviour of zero window probes. 

### DIFF
--- a/fw/tools/docker/esp8266/cs_lwip/src/core/tcp_in.c
+++ b/fw/tools/docker/esp8266/cs_lwip/src/core/tcp_in.c
@@ -312,6 +312,11 @@ void tcp_input(struct pbuf *p, struct netif *inp) {
           ((pcb->refused_data != NULL) && (tcplen > 0))) {
         /* pcb has been aborted or refused data is still refused and the new
            segment contains data */
+        if (pcb->rcv_ann_wnd == 0) {
+          /* this is a zero-window probe, we respond to it with current RCV.NXT
+          and drop the data segment */
+          tcp_send_empty_ack(pcb);
+        }
         TCP_STATS_INC(tcp.drop);
         snmp_inc_tcpinerrs();
         goto aborted;


### PR DESCRIPTION
See http://savannah.nongnu.org/bugs/?49631 for details. Please note that this bugfix was originally introduced for lwip stack 2.x. But as we encountered issues we eventually found this patch to be relevant for lwip stack 1.x as well.

@rojer Please accept this PR. Maybe the docker image needs to be update as well thereafter.