### PR TITLE
 Fix timer created in MGOS_EVENT_TIME_CHANGED handler never gets fired

### DIFF
--- a/fw/src/mgos_timers.c
+++ b/fw/src/mgos_timers.c
@@ -154,13 +154,17 @@ IRAM void mgos_clear_timer(mgos_timer_id id) {
 
 static void mgos_time_change_cb(int ev, void *evd, void *arg) {
   struct timer_data *td = (struct timer_data *) arg;
-  struct mgos_time_changed_arg *ev_data = (struct mgos_time_changed_arg *) evd;
+  const double delta = ((struct mgos_time_changed_arg *) evd)->delta;
   mgos_rlock(s_timer_data_lock);
   struct timer_info *ti;
   LIST_FOREACH(ti, &td->timers, entries) {
     /* 1547596800 is Wed Jan 16 00:00:00 UTC 2019 */
-    if(ti->next_invocation < 1547596800){
-      ti->next_invocation += ev_data->delta;
+    if(delta > 1547596800){
+      if(ti->next_invocation < 1547596800){
+        ti->next_invocation += delta;
+      }
+    }else{
+      ti->next_invocation += delta;
     }
   }
   mgos_runlock(s_timer_data_lock);

--- a/fw/src/mgos_timers.c
+++ b/fw/src/mgos_timers.c
@@ -158,7 +158,10 @@ static void mgos_time_change_cb(int ev, void *evd, void *arg) {
   mgos_rlock(s_timer_data_lock);
   struct timer_info *ti;
   LIST_FOREACH(ti, &td->timers, entries) {
-    ti->next_invocation += ev_data->delta;
+    /* 1547596800 is Wed Jan 16 00:00:00 UTC 2019 */
+    if(ti->next_invocation < 1547596800){
+      ti->next_invocation += ev_data->delta;
+    }
   }
   mgos_runlock(s_timer_data_lock);
 


### PR DESCRIPTION
Timer created in MGOS_EVENT_TIME_CHANGED handler never gets fired:
```
[Jan 16 11:35:51.226] mgos_sntp_ev         SNTP reply from 216.239.35.4: time 1547631352.057400, local 4.872570, delta 1547631347.184830
[Jan 16 11:35:51.231] sntp_time_change_cb  delta=1547631347.172553
[Jan 16 11:35:51.238] timer_create         timer_create - timer2 interval=12000, id=0x3ffbba08
[Jan 16 11:35:51.243] mgos_time_change_cb  delta=1547631347.172553
[Jan 16 11:35:51.252] mgos_time_change_cb  ti=0x3ffbba08 - next_invocation=3095262711.234699 (was 1547631364.062146)
[Jan 16 11:35:51.260] mgos_time_change_cb  ti=0x3ffc7f1c - next_invocation=1547631353.766591 (was 6.594038)
[Jan 16 11:35:51.268] mgos_time_change_cb  ti=0x3ffc8578 - next_invocation=1547631358.592369 (was 11.419816)
[Jan 16 11:35:57.769] timer1_cb            timer1_cb - timer1 interval=11000, id=0x3ffc8578
```

After:
```
[Jan 16 11:55:05.606] mgos_sntp_ev         SNTP reply from 216.239.35.4: time 1547632506.382546, local 4.820541, delta 1547632501.562005
[Jan 16 11:55:05.611] sntp_time_change_cb  delta=1547632501.549685
[Jan 16 11:55:05.618] timer_create         timer_create - timer2 interval=12000, id=0x3ffbb2e4
[Jan 16 11:55:05.623] mgos_time_change_cb  delta=1547632501.549685
[Jan 16 11:55:05.632] mgos_time_change_cb  ti=0x3ffbb2e4 - next_invocation=1547632518.387334 (was 1547632518.387334)
[Jan 16 11:55:05.640] mgos_time_change_cb  ti=0x3ffc7f1c - next_invocation=1547632508.176424 (was 6.626739)
[Jan 16 11:55:05.649] mgos_time_change_cb  ti=0x3ffc8578 - next_invocation=1547632512.970347 (was 11.420662)
[Jan 16 11:55:12.202] timer1_cb            timer1_cb - timer1 interval=11000, id=0x3ffc8578
[Jan 16 11:55:17.619] timer2_cb            timer2_cb - timer2 interval=12000, id=0x3ffbb2e4
```