### PR TITLE
[Fix #393] Failed to set aws.thing_name 

### DIFF
--- a/fw/examples/c_mqtt/mos.yml
+++ b/fw/examples/c_mqtt/mos.yml
@@ -33,5 +33,6 @@ libs:
   - origin: https://github.com/mongoose-os-libs/spi
   - origin: https://github.com/mongoose-os-libs/vfs-dev-spi-flash
   - origin: https://github.com/mongoose-os-libs/wifi
+  - origin: https://github.com/mongoose-os-libs/aws
 build_vars:
   SSL: mbedTLS

--- a/fw/examples/c_mqtt/mos.yml
+++ b/fw/examples/c_mqtt/mos.yml
@@ -19,6 +19,7 @@ config_schema:
   - ["device.password", "test"]
   - ["i2c.enable", true]
 libs:
+  - origin: https://github.com/mongoose-os-libs/aws
   - origin: https://github.com/mongoose-os-libs/ca-bundle
   - origin: https://github.com/mongoose-os-libs/http-server
   - origin: https://github.com/mongoose-os-libs/ota-http-server
@@ -33,6 +34,5 @@ libs:
   - origin: https://github.com/mongoose-os-libs/spi
   - origin: https://github.com/mongoose-os-libs/vfs-dev-spi-flash
   - origin: https://github.com/mongoose-os-libs/wifi
-  - origin: https://github.com/mongoose-os-libs/aws
 build_vars:
   SSL: mbedTLS


### PR DESCRIPTION
Fix  #393 by adding  `origin: https://github.com/mongoose-os-libs/aws` to avoid this [problem](https://github.com/cesanta/mongoose-os/issues/393)

> failed to set aws.thing_name
