### PR TITLE
Added new event: MGOS_EVENT_CLOUD_CONNECTING

### DIFF
--- a/include/mgos_event.h
+++ b/include/mgos_event.h
@@ -101,6 +101,7 @@ enum mgos_event_sys {
    */
   MGOS_EVENT_CLOUD_CONNECTED,
   MGOS_EVENT_CLOUD_DISCONNECTED,
+  MGOS_EVENT_CLOUD_CONNECTING,
 };
 
 /* Parameter for the MGOS_EVENT_CLOUD_* events */


### PR DESCRIPTION
Have been working on a status light library similar to how the Particle boards work. A key thing to know is when the unit is *trying* to connect to the cloud. It will be called by mgos_mqtt.c