### PR TITLE
Prevent infinite loop when calling mgos_gpio_clear_int in an interrupt

### DIFF
--- a/src/mgos_gpio.c
+++ b/src/mgos_gpio.c
@@ -111,7 +111,8 @@ static void mgos_gpio_int_cb(void *arg) {
       mgos_runlock(s_lock);
       s->cb(pin, s->cb_arg);
       mgos_rlock(s_lock);
-      s->cnt--;
+	  if(s->cnt > 0)
+        s->cnt--;
     }
   } else {
     if (s->button.timer_id == MGOS_INVALID_TIMER_ID) {

--- a/src/mgos_gpio.c
+++ b/src/mgos_gpio.c
@@ -111,7 +111,7 @@ static void mgos_gpio_int_cb(void *arg) {
       mgos_runlock(s_lock);
       s->cb(pin, s->cb_arg);
       mgos_rlock(s_lock);
-	  if(s->cnt > 0)
+      if(s->cnt > 0)
         s->cnt--;
     }
   } else {


### PR DESCRIPTION
If mgos_gpio_clear_int is called in an interrupt callback cnt is set to 0 in the clear function.
Then it's decremented in mgos_gpio_int_cb: 0-1=2^16-1 which can start an infinite loop.

```
IRAM void mgos_gpio_clear_int(int pin) {
  struct mgos_gpio_state *s = mgos_gpio_get_state(pin);
  if (s == NULL) return;
  mgos_gpio_hal_clear_int(pin);
  s->cnt = 0;
}

static void mgos_gpio_int_cb(void *arg) {
[...]
  if (s->button.debounce_ms == 0) {
    while (s->cnt > 0) {
      mgos_runlock(s_lock);
      s->cb(pin, s->cb_arg);
      mgos_rlock(s_lock);
      s->cnt--;
    }
  } [...]
}
```