### PR TITLE
Interupts are not always cleared after soft reset (notably GPIO2)

### DIFF
--- a/platforms/esp8266/src/esp_gpio.c
+++ b/platforms/esp8266/src/esp_gpio.c
@@ -207,6 +207,12 @@ void (*mgos_nsleep100)(uint32_t n);
 uint32_t mgos_bitbang_n100_cal;
 
 enum mgos_init_result mgos_gpio_hal_init(void) {
+  // Interupts are not alaway cleared after soft reset (notably GPIO2)
+  // Probably the GPIO2 is triggered because of the second UART - U1TXD, 
+  // which is transmitting data during boot. Clear everything
+  for (int i = 0; i < GPIO_PIN_COUNT; i++) {
+    mgos_gpio_hal_clear_int(i);
+  }
 #ifdef RTOS_SDK
   _xt_isr_attach(ETS_GPIO_INUM, (void *) esp8266_gpio_isr, NULL);
   _xt_isr_unmask(1 << ETS_GPIO_INUM);


### PR DESCRIPTION
After a soft reset when there was an int on GPIO2 mcu can fall into infinite loop. 
Probably the GPIO2 is triggered because of the second UART - U1TXD which is transmitting data during boot.

The isr is continuously trigger (esp8266_gpio_isr) but not forwarded into upper layers for processing because it's not enabled at the gpio lib level. Booting is halted and processors is reset by the hardware wdt.

```
IRAM static void esp8266_gpio_isr(void *arg) {
  uint32_t int_st = GPIO_REG_READ(GPIO_STATUS_ADDRESS);
  for (uint32_t i = 0, mask = 1; i < 16; i++, mask <<= 1) {
    if (!(s_int_config[i] & INT_ENA) || !(int_st & mask)) continue;
    mgos_gpio_hal_int_cb(i);
  }
  (void) arg;
}
```