### PR TITLE
UART pins configured for TTGO T-Call

### DIFF
--- a/platforms/esp32/src/esp32_uart.c
+++ b/platforms/esp32/src/esp32_uart.c
@@ -303,8 +303,8 @@ static void set_default_pins(int uart_no, struct mgos_uart_config *cfg) {
     case 1:
       dcfg->rx_gpio = 27;
       dcfg->tx_gpio = 26;
-      dcfg->cts_gpio = 27;
-      dcfg->rts_gpio = 13;
+      dcfg->cts_gpio = -1;
+      dcfg->rts_gpio = -1;
       break;
     case 2:
       dcfg->rx_gpio = 16;


### PR DESCRIPTION
The above-edited code will inturn make easy communication for ESP32 based TTGO T-Call board to communicate with GSM sim800l placed onboard. UART1 will be used furthermore for all GSM communications. It will solve the issues of ESP32 based TTGO T-Call board users in handling GSM pin configs.