### PR TITLE
Plumbing to allow crosscompiles of Ubuntu to ARM variants

### DIFF
--- a/platforms/ubuntu/Makefile.build
+++ b/platforms/ubuntu/Makefile.build
@@ -23,7 +23,12 @@ APP_EXTRA_FW_PARTS ?=
 
 ASAN ?= 0
 PROF ?= 0
-ARMHF ?= 1
+# COMPILER_TOOLKIT, valid options:
+#   aarch64-linux-gnu
+#   arm-linux-gnueabi
+#   arm-linux-gnueabihf
+#   x86_64-linux-gnu (the default)
+COMPILER_TOOLKIT ?= x86_64-linux-gnu
 
 # Explicitly disable updater, it's not supported on POSIX build yet.
 MGOS_ENABLE_DEBUG_UDP = 0
@@ -63,6 +68,12 @@ C_CXX_FLAGS = -ggdb -MD -Wall -Wextra -Werror -pipe \
               $(MONGOOSE_FEATURES)
 LDFLAGS ?=
 
+# Select compiler toolkit
+CC = $(COMPILER_TOOLKIT)-gcc
+CXX = $(COMPILER_TOOLKIT)-g++
+AR = $(COMPILER_TOOLKIT)-ar
+LD = $(COMPILER_TOOLKIT)-ld
+
 ifeq "$(ASAN)" "1"
 CC = clang
 CXX = clang++
@@ -74,12 +85,6 @@ CC = clang
 CXX = clang++
 C_CXX_FLAGS += -fprofile-instr-generate -fcoverage-mapping
 LDFLAGS += -fprofile-instr-generate
-endif
-ifeq "$(ARMHF)" "1"
-CC = arm-linux-gnueabihf-gcc
-CXX = arm-linux-gnueabihf-g++
-AR = arm-linux-gnueabihf-ar
-LD = arm-linux-gnueabihf-ld
 endif
 
 ifdef MGOS_HAVE_DNS_SD
@@ -93,7 +98,6 @@ CXXFLAGS = -std=gnu++11 -fno-exceptions $(C_CXX_FLAGS) $(APP_CXXFLAGS)
 LDFLAGS += -lstdc++
 
 INCDIRS = $(addprefix -I,$(INCLUDES))
-AR ?= ar
 APP_BIN_LIBS ?=
 LIBS  ?= pthread cap
 LDLIBS = $(addprefix -l,$(LIBS))

--- a/platforms/ubuntu/Makefile.build
+++ b/platforms/ubuntu/Makefile.build
@@ -23,6 +23,7 @@ APP_EXTRA_FW_PARTS ?=
 
 ASAN ?= 0
 PROF ?= 0
+ARMHF ?= 1
 
 # Explicitly disable updater, it's not supported on POSIX build yet.
 MGOS_ENABLE_DEBUG_UDP = 0
@@ -73,6 +74,12 @@ CC = clang
 CXX = clang++
 C_CXX_FLAGS += -fprofile-instr-generate -fcoverage-mapping
 LDFLAGS += -fprofile-instr-generate
+endif
+ifeq "$(ARMHF)" "1"
+CC = arm-linux-gnueabihf-gcc
+CXX = arm-linux-gnueabihf-g++
+AR = arm-linux-gnueabihf-ar
+LD = arm-linux-gnueabihf-ld
 endif
 
 ifdef MGOS_HAVE_DNS_SD

--- a/platforms/ubuntu/src/ubuntu_main.c
+++ b/platforms/ubuntu/src/ubuntu_main.c
@@ -230,7 +230,7 @@ enum mgos_init_result mongoose_init(void) {
   cpu_freq = (int) (mgos_get_cpu_freq() / 1000000);
   heap_size = mgos_get_heap_size();
   free_heap_size = mgos_get_free_heap_size();
-  LOG(LL_INFO, ("CPU: %d MHz, heap: %lu total, %lu free", cpu_freq, heap_size,
+  LOG(LL_INFO, ("CPU: %d MHz, heap: %u total, %zu free", cpu_freq, heap_size,
                 free_heap_size));
 
   mgos_invoke_cb(ubuntu_net_up, NULL, false /* from_isr */);

--- a/platforms/ubuntu/src/ubuntu_main.c
+++ b/platforms/ubuntu/src/ubuntu_main.c
@@ -230,7 +230,7 @@ enum mgos_init_result mongoose_init(void) {
   cpu_freq = (int) (mgos_get_cpu_freq() / 1000000);
   heap_size = mgos_get_heap_size();
   free_heap_size = mgos_get_free_heap_size();
-  LOG(LL_INFO, ("CPU: %d MHz, heap: %u total, %zu free", cpu_freq, heap_size,
+  LOG(LL_INFO, ("CPU: %d MHz, heap: %zu total, %zu free", cpu_freq, heap_size,
                 free_heap_size));
 
   mgos_invoke_cb(ubuntu_net_up, NULL, false /* from_isr */);

--- a/tools/docker/ubuntu/Dockerfile-ubuntu-build
+++ b/tools/docker/ubuntu/Dockerfile-ubuntu-build
@@ -6,7 +6,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
       libexpat-dev libncurses5-dev libtool-bin \
       python python-dev python-git python-pyelftools python-serial python-six python-yaml \
       python3 python3-dev python3-git python3-pyelftools python3-serial python3-six python3-yaml \
-      software-properties-common texinfo unzip wget zip gcc-multilib-arm-linux-gnueabihf g++-arm-linux-gnueabihf && \
+      software-properties-common texinfo unzip wget zip \
+      gcc-multilib-arm-linux-gnueabi g++-arm-linux-gnueabi \
+      gcc-multilib-arm-linux-gnueabihf g++-arm-linux-gnueabihf \
+      gcc-aarch64-linux-gnu g++-aarch64-linux-gnu && \
     apt-get clean
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \

--- a/tools/docker/ubuntu/Dockerfile-ubuntu-build
+++ b/tools/docker/ubuntu/Dockerfile-ubuntu-build
@@ -6,7 +6,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
       libexpat-dev libncurses5-dev libtool-bin \
       python python-dev python-git python-pyelftools python-serial python-six python-yaml \
       python3 python3-dev python3-git python3-pyelftools python3-serial python3-six python3-yaml \
-      software-properties-common texinfo unzip wget zip && \
+      software-properties-common texinfo unzip wget zip gcc-multilib-arm-linux-gnueabihf g++-arm-linux-gnueabihf && \
     apt-get clean
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \


### PR DESCRIPTION
See discussion in https://github.com/cesanta/mongoose-os/issues/533

This PR is non-intrusive, as the default compiler toolkit chosen (`x86_64-linux-gnu`) is the one for AMD64:
```
lrwxrwxrwx 1 root root   5 May 20  2019 /usr/bin/gcc -> gcc-7
lrwxrwxrwx 1 root root   5 May 20  2019 /usr/bin/x86_64-linux-gnu-gcc -> gcc-7
```

Tested the change by compiling a few different applications for a few different targets:

```
for t in arm-linux-gnueabi arm-linux-gnueabihf aarch64-linux-gnu x86_64-linux-gnu; do
  mos build --clean --local --verbose --no-platform-check --build-var=COMPILER_TOOLKIT=$t
done
```

And they all compile cleanly -- although they are missing their `*.a` libraries.