### PR TITLE
Added MGOS_EVENT_CLOUD_CONNECTING

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.vscode
+.idea
+build
+build/***
+core-*
+

--- a/include/mgos_event.h
+++ b/include/mgos_event.h
@@ -101,6 +101,7 @@ enum mgos_event_sys {
    */
   MGOS_EVENT_CLOUD_CONNECTED,
   MGOS_EVENT_CLOUD_DISCONNECTED,
+  MGOS_EVENT_CLOUD_CONNECTING,
 };
 
 /* Parameter for the MGOS_EVENT_CLOUD_* events */


### PR DESCRIPTION
Hi,
Added a simple extra event before it starts trying to connect to MQTT server. The usefulness is having a status light / display that is updating at the various states. Booting/connecting to wifi/connected to wifi/connecting to cloud/connected to GCP etc.