### PR TITLE
docs: fix simple typo, oscilaltor -> oscillator

### DIFF
--- a/platforms/stm32/src/stm32f2_system.c
+++ b/platforms/stm32/src/stm32f2_system.c
@@ -88,7 +88,7 @@ void stm32_clock_config(void) {
   cc.APB2CLKDivider = RCC_HCLK_DIV2;   // 60 MHz
   HAL_RCC_ClockConfig(&cc, FLASH_LATENCY_3);
 
-/* Turn off the unused oscilaltor. */
+/* Turn off the unused oscillator. */
 #if HSE_VALUE == 0
   oc.OscillatorType = RCC_OSCILLATORTYPE_HSE;
   oc.HSEState = RCC_HSE_OFF;

--- a/platforms/stm32/src/stm32f4_system.c
+++ b/platforms/stm32/src/stm32f4_system.c
@@ -96,7 +96,7 @@ void stm32_clock_config(void) {
   /* Use system PLL for USB and RNG. */
   LL_RCC_SetCK48MClockSource(LL_RCC_CK48M_CLKSOURCE_PLL);
 
-/* Turn off the unused oscilaltor. */
+/* Turn off the unused oscillator. */
 #if HSE_VALUE == 0
   oc.OscillatorType = RCC_OSCILLATORTYPE_HSE;
   oc.HSEState = RCC_HSE_OFF;


### PR DESCRIPTION
There is a small typo in platforms/stm32/src/stm32f2_system.c, platforms/stm32/src/stm32f4_system.c.

Should read `oscillator` rather than `oscilaltor`.

