### PR TITLE
Fix closing brace skips after a builtin conversion

### DIFF
--- a/src/frozen/frozen.c
+++ b/src/frozen/frozen.c
@@ -1069,7 +1069,8 @@ int json_vscanf(const char *s, int len, const char *fmt, va_list ap) {
           memcpy(fmtbuf, fmt + i, conv_len);
           fmtbuf[conv_len] = '\0';
           i += conv_len;
-          i += strspn(fmt + i, delims);
+          if (fmt[i] != '}')
+            i += strspn(fmt + i, delims);
           break;
         }
       }


### PR DESCRIPTION
Apply commit 6b14d7aa102aa3190362f2209d38c054eed85c46 from
https://github.com/cesanta/frozen, really.

Wasted a few hours chasing this already fixed bug anew, since
https://mongoose-os.com/docs/mongoose-os/api/core/frozen.h.md points at the
fixed source elsewhere rather than this mismaintained copy: what's the need for
it?  Can't src/frozen be, e.g., a Git module-based Mongoose OS library?