### PR TITLE
Fix a data race issue on the variable locked

### DIFF
--- a/src/mgos_uart.c
+++ b/src/mgos_uart.c
@@ -45,8 +45,8 @@ static inline void uart_lock(struct mgos_uart_state *us) {
 }
 
 static inline void uart_unlock(struct mgos_uart_state *us) {
-  mgos_runlock(us->lock);
   us->locked--;
+  mgos_runlock(us->lock);
 }
 
 IRAM void mgos_uart_schedule_dispatcher(int uart_no, bool from_isr) {


### PR DESCRIPTION
Fix a data race issue due to incorrectly releasing the lock. 