### PR TITLE
build esp32 images for both amd64 and arm64

### DIFF
--- a/tools/docker/cc3200/Dockerfile-cc3200-build
+++ b/tools/docker/cc3200/Dockerfile-cc3200-build
@@ -36,7 +36,8 @@ ADD tmp/$SDK_DIR /opt/$SDK_DIR
 ARG NWP_SP_FILE
 ADD tmp/$NWP_SP_FILE tmp/$NWP_SP_FILE.sign /opt/
 
-ADD mgos_fw_meta.py mklfs mkspiffs mkspiffs8 /usr/local/bin/
+ARG TARGETARCH
+ADD mgos_fw_meta.py $TARGETARCH/mklfs $TARGETARCH/mkspiffs $TARGETARCH/mkspiffs8 /usr/local/bin/
 ADD serve_core/ /opt/serve_core/
 RUN ln -s /opt/serve_core/serve_core.py /usr/local/bin/serve_core.py
 

--- a/tools/docker/cc3220/Dockerfile-cc3220-build
+++ b/tools/docker/cc3220/Dockerfile-cc3220-build
@@ -32,7 +32,8 @@ RUN cd /opt/$TI_COMPILER_DIR/lib && rm *.lib && \
 ARG SDK_DIR
 ADD tmp/$SDK_DIR /opt/$SDK_DIR
 
-ADD mgos_fw_meta.py mklfs mkspiffs mkspiffs8 /usr/local/bin/
+ARG TARGETARCH
+ADD mgos_fw_meta.py $TARGETARCH/mklfs $TARGETARCH/mkspiffs $TARGETARCH/mkspiffs8 /usr/local/bin/
 ADD serve_core/ /opt/serve_core/
 RUN ln -s /opt/serve_core/serve_core.py /usr/local/bin/serve_core.py
 

--- a/tools/docker/docker.mk
+++ b/tools/docker/docker.mk
@@ -29,12 +29,18 @@ docker-pre-build-%: Dockerfile-%
 
 docker-build-%: docker-pre-build-%
 	@echo Building $(REGISTRY)/$*:$(DOCKER_TAG) "$(TOOLCHAIN_URL)"
-	docker buildx build --load $(DOCKER_FLAGS) -t $(REGISTRY)/$*:$(DOCKER_TAG) -f Dockerfile-$* .
+	docker buildx build \
+	--platform $(call clist, $(foreach i, $(PLATFORMS), linux/$(i))) \
+	$(DOCKER_FLAGS) -t $(REGISTRY)/$*:$(DOCKER_TAG) -f Dockerfile-$* .
 	@echo Built $(REGISTRY)/$*:$(DOCKER_TAG)
 
 docker-push-%:
 	docker buildx build --push \
 	--platform $(call clist, $(foreach i, $(PLATFORMS), linux/$(i))) \
+	$(DOCKER_FLAGS) -t $(REGISTRY)/$*:$(DOCKER_TAG) -f Dockerfile-$* .
+
+docker-load-%:
+	docker buildx build --load \
 	$(DOCKER_FLAGS) -t $(REGISTRY)/$*:$(DOCKER_TAG) -f Dockerfile-$* .
 
 mgos_fw_meta.py: $(REPO_PATH)/tools/mgos_fw_meta.py

--- a/tools/docker/docker.mk
+++ b/tools/docker/docker.mk
@@ -9,7 +9,8 @@
 REPO_PATH ?= $(realpath ../../..)
 REGISTRY ?= docker.io/mgos
 DOCKER_TAG ?= latest
-DOCKER_FLAGS ?=
+DOCKER_FLAGS ?= 
+GCC ?= docker.io/gcc
 
 all: docker-build
 
@@ -20,12 +21,12 @@ docker-pre-build-%: Dockerfile-%
 	@true
 
 docker-build-%: docker-pre-build-%
-	@echo Building $(REGISTRY)/$*:$(DOCKER_TAG)
-	docker build $(DOCKER_FLAGS) -t $(REGISTRY)/$*:$(DOCKER_TAG) -f Dockerfile-$* .
+	@echo Building $(REGISTRY)/$*:$(DOCKER_TAG) "$(TOOLCHAIN_URL)"
+	docker buildx build $(DOCKER_FLAGS) -t $(REGISTRY)/$*:$(DOCKER_TAG) -f Dockerfile-$* .
 	@echo Built $(REGISTRY)/$*:$(DOCKER_TAG)
 
 docker-push-%:
-	docker push $(REGISTRY)/$*:$(DOCKER_TAG)
+	docker buildx build --push $(DOCKER_FLAGS) -t $(REGISTRY)/$*:$(DOCKER_TAG) -f Dockerfile-$* .
 
 mgos_fw_meta.py: $(REPO_PATH)/tools/mgos_fw_meta.py
 	cp -v $< .
@@ -33,28 +34,37 @@ mgos_fw_meta.py: $(REPO_PATH)/tools/mgos_fw_meta.py
 serve_core: $(wildcard $(REPO_PATH)/fw/tools/serve_core/*.py)
 	rsync -av $(REPO_PATH)/tools/serve_core/ $@/
 
-mklfs:
+mklfs: mklfs-amd64
+
+mklfs-%:
 	rm -rf vfs-fs-lfs
+	mkdir -p $*
 	git clone --depth=1 https://github.com/mongoose-os-libs/vfs-fs-lfs
 	docker run --rm -it \
+		--platform linux/$* \
 	  -v $(REPO_PATH):/mongoose-os \
 	  -v $(CURDIR)/vfs-fs-lfs:/vfs-fs-lfs \
-	  docker.io/mgos/gcc \
+	  $(GCC) \
 	  bash -c 'make -C /vfs-fs-lfs/tools mklfs \
 	    FROZEN_PATH=/mongoose-os/src/frozen'
-	cp -v vfs-fs-lfs/tools/$@ $@
+	cp -v vfs-fs-lfs/tools/mklfs $*/mklfs
 
-mkspiffs mkspiffs8:
+mkspiffs mkspiffs8 : mkspiffs-amd64 mkspiffs8-amd64
+
+mkspiffs-% mkspiffs8-%:
 	rm -rf vfs-fs-spiffs
+	mkdir -p $*
 	git clone --depth=1 https://github.com/mongoose-os-libs/vfs-fs-spiffs
 	docker run --rm -it \
+		--platform linux/$* \
 	  -v $(REPO_PATH):/mongoose-os \
 	  -v $(CURDIR)/vfs-fs-spiffs:/vfs-fs-spiffs \
-	  docker.io/mgos/gcc \
+	  $(GCC) \
 	  bash -c 'make -C /vfs-fs-spiffs/tools mkspiffs mkspiffs8 \
 	    FROZEN_PATH=/mongoose-os/src/frozen \
 	    SPIFFS_CONFIG_PATH=$(SPIFFS_CONFIG_PATH)'
-	cp -v vfs-fs-spiffs/tools/$@ $@
+	cp -v vfs-fs-spiffs/tools/mkspiffs $*/mkspiffs
+	cp -v vfs-fs-spiffs/tools/mkspiffs8 $*/mkspiffs8
 
 clean-tools:
-	rm -rf mgos_fw_meta.py serve_core serve_core.py mklfs mkspiffs mkspiffs8 vfs-fs-*
+	rm -rf mgos_fw_meta.py serve_core serve_core.py mklfs mkspiffs mkspiffs8 vfs-fs-* arm64 amd64

--- a/tools/docker/esp32/Dockerfile-esp32-build
+++ b/tools/docker/esp32/Dockerfile-esp32-build
@@ -5,7 +5,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
       apt-utils autoconf bison build-essential flex gawk gdb-multiarch git gperf help2man \
       libexpat-dev libncurses5-dev libtool-bin \
       python3 python3-dev python3-git python3-pip python3-pyelftools python3-serial python3-six python3-yaml \
-      python-is-python3 rsync software-properties-common sudo texinfo unzip wget zip && \
+      python-is-python3 rsync software-properties-common sudo texinfo unzip wget zip xz-utils && \
     apt-get clean
 
 RUN cd /tmp && \
@@ -21,15 +21,17 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
 
 RUN useradd -d /opt/Espressif -m -s /bin/bash user && chown -R user /opt
 
-ARG TOOLCHAIN_URL
+ARG TARGETARCH
+ARG TOOLCHAIN_URL=https://github.com/espressif/crosstool-NG/releases/download/esp-2021r2-patch3/xtensa-esp32-elf-gcc8_4_0-esp-2021r2-patch3-linux-${TARGETARCH}.tar.gz
 RUN cd /opt/Espressif && wget -q $TOOLCHAIN_URL && \
-    tar xzf `basename $TOOLCHAIN_URL` && \
+    tar xf `basename $TOOLCHAIN_URL` && \
     rm `basename $TOOLCHAIN_URL`
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/Espressif/xtensa-esp32-elf/bin
 ADD ct_path.sh /etc/profile.d
 
 ARG DOCKER_TAG
 RUN sudo -u user git clone -j 8 --branch $DOCKER_TAG --depth 1 --recursive --shallow-submodules https://github.com/mongoose-os/esp-idf /opt/Espressif/esp-idf
+RUN git config --global --add safe.directory /opt/Espressif/esp-idf
 ENV IDF_PATH=/opt/Espressif/esp-idf
 
 # Apply submodule patches.
@@ -42,7 +44,8 @@ RUN cd $IDF_PATH/tools/kconfig && make conf-idf
 
 ADD rom.bin rom.elf /opt/Espressif/rom/
 
-ADD mgos_fw_meta.py mklfs mkspiffs mkspiffs8 /usr/local/bin/
+ARG TARGETARCH
+ADD mgos_fw_meta.py $TARGETARCH/mklfs $TARGETARCH/mkspiffs $TARGETARCH/mkspiffs8 /usr/local/bin/
 ADD serve_core/ /opt/serve_core/
 RUN ln -s /opt/serve_core/serve_core.py /usr/local/bin/serve_core.py
 

--- a/tools/docker/esp32/Dockerfile-esp32-build
+++ b/tools/docker/esp32/Dockerfile-esp32-build
@@ -5,7 +5,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
       apt-utils autoconf bison build-essential flex gawk gdb-multiarch git gperf help2man \
       libexpat-dev libncurses5-dev libtool-bin \
       python3 python3-dev python3-git python3-pip python3-pyelftools python3-serial python3-six python3-yaml \
-      python-is-python3 rsync software-properties-common sudo texinfo unzip wget zip xz-utils && \
+      python-is-python3 rsync software-properties-common sudo texinfo unzip wget xz-utils zip && \
     apt-get clean
 
 RUN cd /tmp && \

--- a/tools/docker/esp32/Makefile
+++ b/tools/docker/esp32/Makefile
@@ -1,11 +1,20 @@
+e :=
+c := ,
+clist = $(subst $e $e,$c,$(strip $1))
+
 DOCKERFILES = esp32-build
 SPIFFS_CONFIG_PATH = /vfs-fs-spiffs/include/esp32
-TOOLCHAIN_URL = https://github.com/espressif/crosstool-NG/releases/download/esp-2021r2-patch3/xtensa-esp32-elf-gcc8_4_0-esp-2021r2-patch3-linux-amd64.tar.gz
-DOCKER_FLAGS = --build-arg=TOOLCHAIN_URL=$(TOOLCHAIN_URL) \
-               --build-arg=DOCKER_TAG=$(DOCKER_TAG)
+PLATFORMS = arm64 amd64
+
+DOCKER_FLAGS = --build-arg=DOCKER_TAG=$(DOCKER_TAG) \
+               --platform $(call clist, $(foreach i, $(PLATFORMS), linux/$(i)))
 
 include ../docker.mk
 
-docker-pre-build-esp32-build: mgos_fw_meta.py serve_core mklfs mkspiffs mkspiffs8
+docker-pre-build-esp32-build: mgos_fw_meta.py serve_core \
+                              $(foreach i,$(PLATFORMS),mklfs-$(i)) \
+                              $(foreach i,$(PLATFORMS),mkspiffs-$(i)) \
+                              $(foreach i,$(PLATFORMS),mkspiffs8-$(i)) 
+                               
 
 clean: clean-tools

--- a/tools/docker/esp32/Makefile
+++ b/tools/docker/esp32/Makefile
@@ -1,20 +1,12 @@
-e :=
-c := ,
-clist = $(subst $e $e,$c,$(strip $1))
-
 DOCKERFILES = esp32-build
 SPIFFS_CONFIG_PATH = /vfs-fs-spiffs/include/esp32
-PLATFORMS = arm64 amd64
+PLATFORMS = amd64 arm64
 
-DOCKER_FLAGS = --build-arg=DOCKER_TAG=$(DOCKER_TAG) \
-               --platform $(call clist, $(foreach i, $(PLATFORMS), linux/$(i)))
+DOCKER_FLAGS = --build-arg=DOCKER_TAG=$(DOCKER_TAG)
 
 include ../docker.mk
 
-docker-pre-build-esp32-build: mgos_fw_meta.py serve_core \
-                              $(foreach i,$(PLATFORMS),mklfs-$(i)) \
-                              $(foreach i,$(PLATFORMS),mkspiffs-$(i)) \
-                              $(foreach i,$(PLATFORMS),mkspiffs8-$(i)) 
+docker-pre-build-esp32-build: mgos_fw_meta.py serve_core mklfs mkspiffs mkspiffs8 
                                
 
 clean: clean-tools

--- a/tools/docker/esp32c3/Dockerfile-esp32c3-build
+++ b/tools/docker/esp32c3/Dockerfile-esp32c3-build
@@ -49,7 +49,8 @@ RUN cd $IDF_PATH/tools/kconfig && make conf-idf
 
 ADD rom.bin rom.elf /opt/Espressif/rom/
 
-ADD mgos_fw_meta.py mklfs mkspiffs mkspiffs8 /usr/local/bin/
+ARG TARGETARCH
+ADD mgos_fw_meta.py $TARGETARCH/mklfs $TARGETARCH/mkspiffs $TARGETARCH/mkspiffs8 /usr/local/bin/
 ADD serve_core/ /opt/serve_core/
 RUN ln -s /opt/serve_core/serve_core.py /usr/local/bin/serve_core.py
 

--- a/tools/docker/esp8266/Dockerfile-esp8266-build
+++ b/tools/docker/esp8266/Dockerfile-esp8266-build
@@ -46,7 +46,8 @@ RUN mv /opt/Espressif/ESP8266_NONOS_SDK/lib/libc.a /opt/Espressif/ESP8266_NONOS_
 
 ADD rom.bin rom.elf /opt/Espressif/rom/
 
-ADD mgos_fw_meta.py mklfs mkspiffs mkspiffs8 /usr/local/bin/
+ARG TARGETARCH
+ADD mgos_fw_meta.py $TARGETARCH/mklfs $TARGETARCH/mkspiffs $TARGETARCH/mkspiffs8 /usr/local/bin/
 ADD serve_core/ /opt/serve_core/
 RUN ln -s /opt/serve_core/serve_core.py /usr/local/bin/serve_core.py
 

--- a/tools/docker/rs14100/Dockerfile-rs14100-build-private
+++ b/tools/docker/rs14100/Dockerfile-rs14100-build-private
@@ -21,7 +21,8 @@ RUN DEBIAN_FRONTEND=noninteractive add-apt-repository -y -u ppa:team-gcc-arm-emb
 ARG RS14100_SDK
 ADD tmp/$RS14100_SDK /opt/$RS14100_SDK
 
-ADD mgos_fw_meta.py mklfs mkspiffs mkspiffs8 /usr/local/bin/
+ARG TARGETARCH
+ADD mgos_fw_meta.py $TARGETARCH/mklfs $TARGETARCH/mkspiffs $TARGETARCH/mkspiffs8 /usr/local/bin/
 ADD serve_core/ /opt/serve_core/
 RUN ln -s /opt/serve_core/serve_core.py /usr/local/bin/serve_core.py
 

--- a/tools/docker/stm32/Dockerfile-stm32-build
+++ b/tools/docker/stm32/Dockerfile-stm32-build
@@ -41,7 +41,8 @@ ARG STM32CUBE_F7_DIR
 ADD tmp/$STM32CUBE_F7_DIR /opt/$STM32CUBE_F7_DIR
 ENV STM32CUBE_F7_PATH /opt/$STM32CUBE_F7_DIR
 
-ADD mgos_fw_meta.py mklfs mkspiffs mkspiffs8 /usr/local/bin/
+ARG TARGETARCH
+ADD mgos_fw_meta.py $TARGETARCH/mklfs $TARGETARCH/mkspiffs $TARGETARCH/mkspiffs8 /usr/local/bin/
 ADD serve_core/ /opt/serve_core/
 RUN ln -s /opt/serve_core/serve_core.py /usr/local/bin/serve_core.py
 


### PR DESCRIPTION
This will build images for esp32 both for amd64 and arm64. 
- use official gcc docker image for building instead of mgos/cc
- use docker builder for building the images (buildx, builder needs to be setup before being able to build, see https://docs.docker.com/desktop/multi-arch/)
- TOOLCHAIN_URL moved into Dockerfile as it is arch dependent now and I couldn't figure out a way to pass arch specific build-args to docker
- Caveat: when building images they are not easily accessible locally from docker before pushing to registry, essentially there is also no separate push command. I was only be able to load single arch images into docker directly.
- also added xz-utils to Dockerfile as it looks like Espressif is using xz compression from next release.
Prerequesites:
- rojer/fsync-stub library need to be updated with the pull request I submitted there to also build arm64 lib
- run docker buildx create --name mybuilder --use to create a new builder 

TODO: 
- also create multi arch images for esp8266 and others, if possible