### PR TITLE
mgos_set_timer(): fix early REPEAT | RUN_NOW combo

### DIFF
--- a/src/mgos_timers.c
+++ b/src/mgos_timers.c
@@ -120,11 +120,8 @@ mgos_timer_id mgos_set_timer(int msecs, int flags, timer_callback cb,
     ti->interval_ms = -1;
   }
   double now = mgos_uptime();
-  if (flags & MGOS_TIMER_RUN_NOW) {
-    ti->next_invocation = 1;
-  } else {
-    ti->next_invocation = now + msecs / 1000.0;
-  }
+  ti->next_invocation = now;
+  if (!(flags & MGOS_TIMER_RUN_NOW)) ti->next_invocation += msecs / 1000.0;
   ti->cb = cb;
   ti->cb_arg = arg;
   {


### PR DESCRIPTION
Invocations of MGOS_TIMER_REPEAT timers could be wrongly timed when combined
with MGOS_TIMER_RUN_NOW no earlier than one timer delay after a reboot.  The
likelihood of this problem grew considerably after the “Use uptime for timers”
commit 00b9fca365afab2adc8a3d73c9dde796366aca24.

The bug is in the interaction of the “ti->next_invocation = 1”
MGOS_TIMER_RUN_NOW hack in mgos_set_timer() and the “ti->next_invocation +=
intvl” calculation of when MGOS_TIMER_REPEAT will run next in mgos_timer_ev(),
where the subsequent “ti->next_invocation < now” sanity check won't trigger
until mgos_uptime() is at least one timer period's worth + 1.

Fix by removing the “= 1” hack.