### PR TITLE
docker esp32: fix failing builds on linux

### DIFF
--- a/tools/docker/esp32/Dockerfile-esp32-build
+++ b/tools/docker/esp32/Dockerfile-esp32-build
@@ -19,7 +19,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
       python2 python2-dev && \
     apt-get clean
 
-RUN useradd -d /opt/Espressif -m -s /bin/bash user && chown -R user /opt
+RUN useradd -d /opt/Espressif -m -s /bin/bash user && chmod o+rx /opt/Espressif
 
 ARG TARGETARCH
 ARG TOOLCHAIN_URLS="https://github.com/espressif/crosstool-NG/releases/download/esp-2021r2-patch3/xtensa-esp32-elf-gcc8_4_0-esp-2021r2-patch3-linux-${TARGETARCH}.tar.gz https://github.com/espressif/crosstool-NG/releases/download/esp-2021r2-patch3/riscv32-esp-elf-gcc8_4_0-esp-2021r2-patch3-linux-${TARGETARCH}.tar.gz https://github.com/espressif/crosstool-NG/releases/download/esp-2021r2-patch3/xtensa-esp32s3-elf-gcc8_4_0-esp-2021r2-patch3-linux-${TARGETARCH}.tar.gz"


### PR DESCRIPTION
when building with mos build, the docker container is called with the current userid on the host, which might not necessarily exist within the docker container. The folder of the 'user' (/opt/Espressif) needs to be accessed in the build by this other user, but cannot, as the permission on useradd is set to 0 for others. This works around the issue by extending the permissions for other users