### PR TITLE
fully qualified call to link.py

### DIFF
--- a/platforms/esp32/CMakeLists.txt
+++ b/platforms/esp32/CMakeLists.txt
@@ -1,23 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
-set(PYTHON_DEPS_CHECKED 1)  # Save some build time
-set(EXTRA_CFLAGS $ENV{EXTRA_CFLAGS})
-set(EXTRA_CPPFLAGS $ENV{EXTRA_CPPFLAGS})
-set(EXTRA_CXXFLAGS $ENV{EXTRA_CXXFLAGS})
+
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project($ENV{APP})
 
-# Add binary libs.
-separate_arguments(app_bin_libs NATIVE_COMMAND "$ENV{APP_BIN_LIBS}")
-foreach(bin_lib ${app_bin_libs})
-  get_filename_component(target_name ${bin_lib} NAME_WLE)
-  add_prebuilt_library(${target_name} ${bin_lib})
-  target_link_libraries(${CMAKE_PROJECT_NAME}.elf ${target_name})
-endforeach()
-
-# ESP-IDF passes component libs multiple times to the linker.
-# This looks like a bug but is not a problem unless they are --whole-archive's.
-# Which is what we want to do, since that is the only way to make sure weak
-# functions are overridden by non-weak ones, which we definitely want to happen.
-# We wrap the link command with a script that dedupes the static libs,
-# puts them in a group and wraps with --whole-archive.
-set(CMAKE_CXX_LINK_EXECUTABLE "/mongoose-os/tools/link.py <CMAKE_CXX_COMPILER> <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
+include(../esp32xx/esp32xx.cmake)

--- a/platforms/esp32c3/CMakeLists.txt
+++ b/platforms/esp32c3/CMakeLists.txt
@@ -1,23 +1,3 @@
 cmake_minimum_required(VERSION 3.5)
-set(PYTHON_DEPS_CHECKED 1)  # Save some build time
-set(EXTRA_CFLAGS $ENV{EXTRA_CFLAGS})
-set(EXTRA_CPPFLAGS $ENV{EXTRA_CPPFLAGS})
-set(EXTRA_CXXFLAGS $ENV{EXTRA_CXXFLAGS})
-include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project($ENV{APP})
-
-# Add binary libs.
-separate_arguments(app_bin_libs NATIVE_COMMAND "$ENV{APP_BIN_LIBS}")
-foreach(bin_lib ${app_bin_libs})
-  get_filename_component(target_name ${bin_lib} NAME_WLE)
-  add_prebuilt_library(${target_name} ${bin_lib})
-  target_link_libraries(${CMAKE_PROJECT_NAME}.elf ${target_name})
-endforeach()
-
-# ESP-IDF passes component libs multiple times to the linker.
-# This looks like a bug but is not a problem unless they are --whole-archive's.
-# Which is what we want to do, since that is the only way to make sure weak
-# functions are overridden by non-weak ones, which we definitely want to happen.
-# We wrap the link command with a script that dedupes the static libs,
-# puts them in a group and wraps with --whole-archive.
-set(CMAKE_CXX_LINK_EXECUTABLE "/mongoose-os/tools/link.py <CMAKE_CXX_COMPILER> <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
+include(../esp32xx/esp32xx.cmake)

--- a/platforms/esp32xx/Makefile.build
+++ b/platforms/esp32xx/Makefile.build
@@ -142,6 +142,7 @@ export EXTRA_CFLAGS = $(APP_CFLAGS)
 export EXTRA_CXXFLAGS = $(APP_CXXFLAGS)
 
 export APP
+export MGOS_PATH
 export MGOS_ESP_PATH
 
 ifeq "$(VERBOSE)" "1"

--- a/platforms/esp32xx/esp32xx.cmake
+++ b/platforms/esp32xx/esp32xx.cmake
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.5)
+set(PYTHON_DEPS_CHECKED 1)  # Save some build time
+set(EXTRA_CFLAGS $ENV{EXTRA_CFLAGS})
+set(EXTRA_CPPFLAGS $ENV{EXTRA_CPPFLAGS})
+set(EXTRA_CXXFLAGS $ENV{EXTRA_CXXFLAGS})
+
+# Add binary libs.
+separate_arguments(app_bin_libs NATIVE_COMMAND "$ENV{APP_BIN_LIBS}")
+foreach(bin_lib ${app_bin_libs})
+  get_filename_component(target_name ${bin_lib} NAME_WLE)
+  add_prebuilt_library(${target_name} ${bin_lib})
+  target_link_libraries(${CMAKE_PROJECT_NAME}.elf ${target_name})
+endforeach()
+
+# ESP-IDF passes component libs multiple times to the linker.
+# This looks like a bug but is not a problem unless they are --whole-archive's.
+# Which is what we want to do, since that is the only way to make sure weak
+# functions are overridden by non-weak ones, which we definitely want to happen.
+# We wrap the link command with a script that dedupes the static libs,
+# puts them in a group and wraps with --whole-archive.
+set(CMAKE_CXX_LINK_EXECUTABLE "$ENV{MGOS_PATH}/tools/link.py <CMAKE_CXX_COMPILER> <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")


### PR DESCRIPTION
Removes some unnecessary redundancy between identical CMakeLists.txt for esp32 and esp32c3 and fully qualifies the call to link.py relative to the `mongoose-os` dependency being used instead of using a hard-coded absolute path