### PR TITLE
fix for issue 605, CMakeLists.txt for esp32c3 and esp32 shared

### DIFF
--- a/platforms/esp32c3/CMakeLists.txt
+++ b/platforms/esp32c3/CMakeLists.txt
@@ -1,3 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project($ENV{APP})
+
 include(../esp32xx/esp32xx.cmake)


### PR DESCRIPTION
The idea behind the previous PR was to reduce redundancy between esp32 and esp32c3 since their CMakeLists.txt were identical. Unfortunately, the 'include' stub of both should have also been identical, but weren't. And I did not test building for esp32c3.

I tested now as follows:

```
$ mos update latest
$ mos clone https://github.com/mongoose-os-apps/demo-js app1
$ mos build ... --platform esp32 # succeeds
$ mos build ... --platform esp32c3 #fails 
# apply this PR
$ rm -rf build
$ mos build ... --platform esp32c3 #succeeds
$ mos build ... --platform esp32 # succeeds
```
 I'm not sure how you typically go about testing the build system...

https://github.com/cesanta/mongoose-os/issues/605