### PR TITLE
mgos::Timer - get time left until invocation

### DIFF
--- a/include/mgos_timers.hpp
+++ b/include/mgos_timers.hpp
@@ -38,9 +38,11 @@ class Timer {
 
   bool Reset(int msecs, int flags);
 
-  bool IsValid();
+  bool IsValid() const;
 
- private:
+  int GetMsecsLeft() const;
+
+ protected:
   static void HandlerCB(void *arg);
 
   Handler handler_;

--- a/src/mgos_timers.cpp
+++ b/src/mgos_timers.cpp
@@ -51,8 +51,17 @@ bool Timer::Reset(int msecs, int flags) {
   return IsValid();
 }
 
-bool Timer::IsValid() {
+bool Timer::IsValid() const {
   return (id_ != MGOS_INVALID_TIMER_ID);
+}
+
+int Timer::GetMsecsLeft() const {
+  if (!IsValid()) return 0;
+  struct mgos_timer_info ti;
+  if (mgos_get_timer_info(id_, &ti)) {
+    return ti.msecs_left;
+  }
+  return 0;
 }
 
 // static


### PR DESCRIPTION
mgos::Timer did not have public method to get time left until next invocation,
neither it was extendable to add such method in a child class

Changes:
- exposed GetMsecsLeft API to get time left until invocation
- changed "private" to "proteted" to make it extendable